### PR TITLE
Add rebase method in Gitlab

### DIFF
--- a/gitlab/src/main/scala/io/pg/gitlab/Gitlab.scala
+++ b/gitlab/src/main/scala/io/pg/gitlab/Gitlab.scala
@@ -31,6 +31,7 @@ import sttp.tapir.Endpoint
 trait Gitlab[F[_]] {
   def mergeRequests(projectId: Long): F[List[MergeRequestInfo]]
   def acceptMergeRequest(projectId: Long, mergeRequestIid: Long): F[Unit]
+  def rebaseMergeRequest(projectId: Long, mergeRequestIid: Long): F[Unit]
 }
 
 object Gitlab {
@@ -158,6 +159,11 @@ object Gitlab {
         runInfallibleEndpoint(GitlabEndpoints.acceptMergeRequest)
           .apply((projectId, mergeRequestIid))
           .void
+
+      def rebaseMergeRequest(projectId: Long, mergeRequestIid: Long): F[Unit] =
+        runInfallibleEndpoint(GitlabEndpoints.rebaseMergeRequest)
+          .apply((projectId, mergeRequestIid))
+          .void
     }
   }
 
@@ -173,10 +179,15 @@ object GitlabEndpoints {
     baseEndpoint
       //hehe putin
       .put
-      .in(
-        "projects" / path[Long]("id") / "merge_requests" / path[Long](
-          "merge_request_iid"
-        ) / "merge"
-      )
+      .in("projects" / path[Long]("projectId"))
+      .in("merge_requests" / path[Long]("merge_request_iid"))
+      .in("merge")
+
+  val rebaseMergeRequest: Endpoint[(Long, Long), Nothing, Unit, Nothing] =
+    baseEndpoint
+      .put
+      .in("projects" / path[Long]("projectId"))
+      .in("merge_requests" / path[Long]("merge_request_iid"))
+      .in("rebase")
 
 }


### PR DESCRIPTION
Closes #87﻿

Tested manually, this always returns "accepted" if the MR exists, even if the rebase is impossible due to conflicts. I think that's acceptable and we'll find a way to catch that case anyway.
