### PR TITLE
Restore sbt-missinglink usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,7 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
-      - name: Build project
-        run: sbt ++${{ matrix.scala }} test
+      - run: sbt ++${{ matrix.scala }} test missinglinkCheck
 
       - name: Compress target directories
         run: tar cf targets.tar target gitlab/target core/target project/target

--- a/build.sbt
+++ b/build.sbt
@@ -45,9 +45,9 @@ ThisBuild / githubWorkflowPublishPreamble := Seq(
 ThisBuild / githubWorkflowPublish := Seq(WorkflowStep.Sbt(List("docker:publish")))
 
 // todo: reenable missinglink
-//ThisBuild / githubWorkflowBuild := List(
-//  WorkflowStep.Sbt(List("test", "missinglinkCheck"))
-//)
+ThisBuild / githubWorkflowBuild := List(
+  WorkflowStep.Sbt(List("test", "missinglinkCheck"))
+)
 
 Test / fork := true
 


### PR DESCRIPTION
Some recent changes in sbt-missinglink (like workarounds for the lack of thread safety of missinglink itself in https://github.com/scalacenter/sbt-missinglink/releases/tag/v0.3.1) seem to have fixed its behavior here, so I'm reenabling it.